### PR TITLE
sway: fix type error when class_name none

### DIFF
--- a/.local/bin/sway-autoname-workspaces
+++ b/.local/bin/sway-autoname-workspaces
@@ -54,7 +54,7 @@ def icon_for_window(window):
     else:
         # xwayland support
         class_name = window.window_class
-        if len(class_name) > 0:
+        if class_name is not None and len(class_name) > 0:
             class_name = class_name.lower()
             if class_name in WINDOW_ICONS:
                 return WINDOW_ICONS[class_name]


### PR DESCRIPTION
Same as in [this line](https://github.com/maximbaz/dotfiles/blob/master/.local/bin/sway-autoname-workspaces#L49), fix the TypeError when  class_name is of type `NoneType`.

Found out about this problem while screen sharing in my chromium and it opens a new window. :slightly_smiling_face: 