### PR TITLE
waybar-yubikey: Avoid subshell for `nc | while read`

### DIFF
--- a/.local/bin/waybar-yubikey
+++ b/.local/bin/waybar-yubikey
@@ -11,7 +11,7 @@ while true; do
     fi
     printf '{"text": ""}\n'
 
-    nc -U "$socket" | while read -n5 cmd; do
+    while read -n5 cmd; do
         reason="${cmd:0:3}"
 
         if [ "${cmd:4:1}" = "1" ]; then
@@ -31,7 +31,7 @@ while true; do
             tooltip="YubiKey is waiting for a touch, reasons: ${touch_reasons[@]}"
             printf '{"text": "  ", "tooltip": "%s"}\n' "$tooltip"
         fi
-    done
+    done < <(nc -U "$socket")
 
     sleep 1
 done


### PR DESCRIPTION
I have a slightly different version of this that I copied from you, here:

https://gitlab.com/mmonaco/dotfiles/-/blob/master/.config/waybar/yubikey

I noticed that my old loginctl sessions were sticking around because for whatever reason, the waybar custom module's `killpg()` wasn't fully killing the bash+nc process group. Avoiding a subshell fixes/works-around this issue (I don't use logind's KillUserProcesses). Ditto when restarting waybar, I'd have cruft leftover from old "waybar-yubikey" invocations.

Here's my dotfiles change for reference: 

https://gitlab.com/mmonaco/dotfiles/-/commit/78e23f5d51bf1a4e206386046ef085c937c832b5