### PR TITLE
qutebrowser:Fix a clipboard variables

### DIFF
--- a/.config/qutebrowser/config.py
+++ b/.config/qutebrowser/config.py
@@ -16,7 +16,7 @@ c.tabs.title.format_pinned = "{index}: {audio}{current_title}"
 # general
 c.auto_save.session = True
 c.content.default_encoding = "utf-8"
-c.content.javascript.can_access_clipboard = True
+c.content.javascript.clipboard = "access"
 c.content.notifications.enabled = True
 c.editor.command = ["kitty", "kak", "-e", "exec {line}g{column0}l", "{}"]
 c.fileselect.handler = "external"


### PR DESCRIPTION
Hello.I usually use firefox and have not used qutebrowser much. However, I wanted to try it out, and when I was adding the config, I found a old variables.

qutebrowser deleted `content.javascript.can_access_clipboard`   and add  new variable as `content.javascript.clipboard`  at https://github.com/qutebrowser/qutebrowser/commit/4a6df3a8e84780e9f58dbda31c3a9bfa1e35cebe